### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ I should also add that this utility/plugin was inspired by [Dustin Diaz's][]
 [detect when an element scrolls in to view code][].
 
 
-##Demo
+## Demo
 
 The example is mostly *lorem* text, but in the middle of the page is an element
 whose text reads: "You can't see me". When the element is scrolled in to view


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
